### PR TITLE
Be explicit about decoding of keys in the spec.

### DIFF
--- a/Spec.md
+++ b/Spec.md
@@ -27,6 +27,9 @@ fields:
 - *Signing-key*, 128 bits
 - *Encryption-key*, 128 bits
 
+Fernet keys are URL-safe base-64 encoded to ease their management,
+they must be decoded and split into their component parts before use.
+
 ## Token Format
 
 A fernet *token* is the URL-safe base-64 encoding of the


### PR DESCRIPTION
Some reviewers of `cryptography.fernet` were confused by the  encoding in the key generation step, partially because no explicit instructions for decoding were part of the spec.

It may also be desirable to explicitly add decoding as a step in the verifying workflow after determining the version of the token.
