### PR TITLE
require strict base64 decoding

### DIFF
--- a/Spec.md
+++ b/Spec.md
@@ -16,6 +16,9 @@ All encryption in this version is done with AES 128 in CBC mode.
 All base 64 encoding is done with the "URL and Filename Safe"
 variant, defined in [RFC 4648](http://tools.ietf.org/html/rfc4648#section-5) as "base64url".
 
+Implementations **MUST** implement strict checking of the base64 payload. This means
+rejection of invalid characters as well as additional characters after the padding byte(s).
+
 ## Key Format
 
 A fernet *key* is the base64url encoding of the following
@@ -110,7 +113,8 @@ Given a key and token, to verify that the token is valid and
 recover the original message, perform the following steps, in
 order:
 
-1. base64url decode the token.
+1. base64url decode the token rejecting any token that has invalid
+   characters or bytes after padding.
 2. Ensure the first byte of the token is 0x80.
 3. If the user has specified a maximum age (or "time-to-live") for
 the token, ensure the recorded timestamp is not too far in the

--- a/invalid.json
+++ b/invalid.json
@@ -54,5 +54,26 @@
     "now": "1985-10-26T01:20:01-07:00",
     "ttl_sec": 60,
     "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "trailing characters after b64 padding",
+    "token": "gAAAAAAdwJ6wAAECAwQFBgcICQoLDA0ODy021cpGVWKZ_eEwCGM4BLLF_5CV9dOPmrhuVUPgJobwOz7JcbmrR64jVmpU4IwqDA==trailingdata",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "invalid characters in b64",
+    "token": "*gAAAAAAdwJ6wAAECAwQFBgcI!CQoLDA0ODy021?cpGVWKZ_eEwC@GM4BLLF_5CV9dOPmrhuVUPgJobwOz7JcbmrR64jVmpU4IwqDA==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
+  },
+  {
+    "desc": "invalid non-urlsafe characters in b64",
+    "token": "gAAAAAAdwJ6wAAEC/AwQFBgcICQoLDA0ODy+021cpGVWKZ_eEwCGM4BLLF_5CV9dOPmrhuVUPgJobwOz7JcbmrR64jVmpU4IwqDA==",
+    "now": "1985-10-26T01:20:01-07:00",
+    "ttl_sec": 60,
+    "secret": "cw_0x689RpI-jtRR7oE8h_eQsKImvJapLeSbXpwF4e4="
   }
 ]


### PR DESCRIPTION
Fernet tokens use URL safe base64 encoding. Platforms like Python (and Ruby, etc) have chosen to implement decoding of this in a very liberal way. Specifically, characters outside the base64 alphabet are silently dropped and parsing is terminated when valid padding is detected. This is at odds with the recommendations in RFC 4648 (section 3.3), but is not explicitly disallowed. In practice this means it is possible to take a valid Fernet token and craft one that appears different (e.g. with invalid characters or garbage after the padding char(s)) that will still validate. This is a problem as clients may not realize that, counterintuitively, the token is semi-mutable prior to decoding without affecting the HMAC.

The proposed fix is to add new invalid test vectors that exercise these behaviors and require conformant implementations to do more rigorous checking on the base64 prior to decoding. In Python this might look like:

```python
INVALID_B64_RE = re.compile("[^-A-Za-z0-9_=]|=[^=]|===$")
if INVALID_B64_RE.search(token):
    raise InvalidToken
```
